### PR TITLE
Iteratively estimate noise using method from grpSLOPE if sigma is not provided

### DIFF
--- a/R/families.R
+++ b/R/families.R
@@ -5,13 +5,18 @@ setClass("Family",
 setClass("Gaussian", contains = "Family")
 setClass("Binomial", contains = "Family")
 
-setGeneric("lambdaMax",
-           function(object, x, y, y_scale) standardGeneric("lambdaMax"))
+setGeneric(
+  "lambdaMax",
+  function(object, x, y, y_scale)
+    standardGeneric("lambdaMax")
+)
 
-setMethod("lambdaMax",
-          "Gaussian",
-          function(object, x, y, y_scale)
-            y_scale*max(abs(crossprod(x, y)))/NROW(x))
+setMethod(
+  "lambdaMax",
+  "Gaussian",
+  function(object, x, y, y_scale)
+    y_scale*max(abs(crossprod(x, y)))/NROW(x)
+)
 
 setMethod(
   "lambdaMax",
@@ -30,49 +35,57 @@ setMethod(
   }
 )
 
-setGeneric("lipschitzConstant",
-           function(object, x, fit_intercept)
-             standardGeneric("lipschitzConstant"))
+setGeneric(
+  "lipschitzConstant",
+  function(object, x, fit_intercept)
+    standardGeneric("lipschitzConstant")
+)
 
-setMethod("lipschitzConstant",
-          "Gaussian",
-          function(object, x, fit_intercept) {
-            max(rowSums(x^2)) + fit_intercept
-          })
+setMethod(
+  "lipschitzConstant",
+  "Gaussian",
+  function(object, x, fit_intercept) {
+    max(rowSums(x^2)) + fit_intercept
+  }
+)
 
-setMethod("lipschitzConstant",
-          "Binomial",
-          function(object, x, fit_intercept) {
-            0.25 * (max(rowSums(x^2)) + fit_intercept)
-          })
+setMethod(
+  "lipschitzConstant",
+  "Binomial",
+  function(object, x, fit_intercept) {
+    0.25 * (max(rowSums(x^2)) + fit_intercept)
+  }
+)
 
 setGeneric("preprocessResponse",
            function(object, y) standardGeneric("preprocessResponse"))
 
-setMethod("preprocessResponse",
-          "Gaussian",
-          function(object, y) {
-            m <- NCOL(y)
+setMethod(
+  "preprocessResponse",
+  "Gaussian",
+  function(object, y) {
+    m <- NCOL(y)
 
-            if (!is.numeric(y))
-              stop("non-numeric response.")
+    if (!is.numeric(y))
+      stop("non-numeric response.")
 
-            if (m > 1)
-              stop("response for Gaussian regression must be one-dimensional.")
+    if (m > 1)
+      stop("response for Gaussian regression must be one-dimensional.")
 
-            y <- as.numeric(y)
+    y <- as.numeric(y)
 
-            y_center <- mean(y)
-            #y_scale  <- sd(y)
-            y_scale  <- 1
+    y_center <- mean(y)
+    #y_scale  <- sd(y)
+    y_scale  <- 1
 
-            y <- as.matrix(y - y_center)
-            attr(y, "center") <- y_center
-            attr(y, "scale") <- y_scale
-            attr(y, "n_classes") <- 1
-            attr(y, "class_names") <- NA_character_
-            y
-          })
+    y <- as.matrix(y - y_center)
+    attr(y, "center") <- y_center
+    attr(y, "scale") <- y_scale
+    attr(y, "n_classes") <- 1
+    attr(y, "class_names") <- NA_character_
+    y
+  }
+)
 
 setMethod(
   "preprocessResponse",
@@ -105,8 +118,11 @@ setMethod(
   }
 )
 
-setGeneric("link",
-           function(object, lin_pred) standardGeneric("link"))
+setGeneric(
+  "link",
+  function(object, lin_pred)
+    standardGeneric("link")
+)
 
 setMethod("link",
           "Family",

--- a/R/penalties.R
+++ b/R/penalties.R
@@ -22,8 +22,8 @@ Slope <- function(lambda = c("gaussian", "bhq"),
 
   # noise estimate
   if (is.null(sigma)) {
-    sigma <- 1 # temporarily set sigma to 1
     sigma_type <- "auto"
+    sigma <- NA_real_
   } else {
     stopifnot(length(sigma) == 1)
     sigma_type <- "user"
@@ -78,8 +78,8 @@ GroupSlope <- function(groups,
 
   # noise estimate
   if (is.null(sigma)) {
-    sigma <- 1 # temporarily set sigma to 1
     sigma_type <- "auto"
+    sigma <- NA_real_
   } else {
     stopifnot(length(sigma) == 1)
     sigma_type <- "user"
@@ -218,8 +218,8 @@ setMethod(
 
     n_groups      <- length(group_id)
 
-    wt                 <- attr(x, "wt")
-    n                  <- attr(x, "n")
+    wt <- attr(x, "wt")
+    n  <- attr(x, "n")
     wt <- object@wt
 
     group_sizes <- if (orthogonalize)

--- a/tests/testthat/test-group-slope.R
+++ b/tests/testthat/test-group-slope.R
@@ -72,3 +72,21 @@ test_that("group_slope lambda sequences are computed properly", {
 
 
 })
+
+test_that("sigma estimation for Group SLOPE", {
+  set.seed(1)
+
+  problem <- golem:::random_problem(10, 5, sigma = 1)
+
+  x <- problem$x
+  y <- problem$y
+  groups <- c(1, 1, 2, 2, 2)
+
+  slope_fit <- grpSLOPE::grpSLOPE(x, y, group = groups, fdr = 0.2)
+  golem_fit <- golem::golem(x, y, penalty = "group_slope",
+                            fdr = 0.2,
+                            groups = groups)
+
+  expect_equal(slope_fit$sigma[length(slope_fit$sigma)],
+               golem_fit@penalty@sigma)
+})

--- a/tests/testthat/test-slope.R
+++ b/tests/testthat/test-slope.R
@@ -33,3 +33,19 @@ test_that("SLOPE and golem agree when computing lambda sequences", {
     expect_equivalent(golem_lambda, slope_lambda)
   }
 })
+
+
+test_that("sigma estimation for SLOPE", {
+  set.seed(1)
+
+  problem <- golem:::random_problem(10, 5, sigma = 1)
+
+  x <- problem$x
+  y <- problem$y
+
+  slope_fit <- SLOPE::SLOPE(x, y)
+  golem_fit <- golem::golem(x, y, penalty = "slope", intercept = FALSE)
+
+  expect_equal(slope_fit$sigma[length(slope_fit$sigma)],
+               golem_fit@penalty@sigma)
+})

--- a/vignettes/golem.bib
+++ b/vignettes/golem.bib
@@ -35,4 +35,18 @@
   pages = {267-288}
 }
 
+@article{su2016,
+  title = {{{SLOPE}} Is Adaptive to Unknown Sparsity and Asymptotically Minimax},
+  volume = {44},
+  issn = {0090-5364, 2168-8966},
+  language = {EN},
+  number = {3},
+  journal = {The Annals of Statistics},
+  doi = {10.1214/15-AOS1397},
+  author = {Su, Weijie and Cand{\`e}s, Emmanuel},
+  month = jun,
+  year = {2016},
+  pages = {1038-1068}
+}
+
 


### PR DESCRIPTION
The changes in this pull request will add functionality to `golem()`, enabling estimation of noise (`sigma`) by an iterative procedure from Bryzki et al for gaussian responses.

In essence, we start with a fit based on `sigma` equal to the standard deviation of the response vector. Then we run a while loop; for each iteration, a regular OLS model is fit using the current active set of predictors and we update the `sigma` estimate using the mean residual sums of squares for the OLS fit. The loop is run until the active set does not change in a new iteration.