### PR TITLE
Performance improvements and fix lipschitz computations for group slope

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -82,6 +82,7 @@ Collate:
     'data.R'
     'golem-package.R'
     'groupslope-lambda.R'
+    'lipschitz-constant.R'
     'post-processing.R'
     'pre-processing.R'
     'predict.R'

--- a/R/families.R
+++ b/R/families.R
@@ -35,28 +35,6 @@ setMethod(
   }
 )
 
-setGeneric(
-  "lipschitzConstant",
-  function(object, x, fit_intercept)
-    standardGeneric("lipschitzConstant")
-)
-
-setMethod(
-  "lipschitzConstant",
-  "Gaussian",
-  function(object, x, fit_intercept) {
-    max(rowSums(x^2)) + fit_intercept
-  }
-)
-
-setMethod(
-  "lipschitzConstant",
-  "Binomial",
-  function(object, x, fit_intercept) {
-    0.25 * (max(rowSums(x^2)) + fit_intercept)
-  }
-)
-
 setGeneric("preprocessResponse",
            function(object, y) standardGeneric("preprocessResponse"))
 

--- a/R/golem.R
+++ b/R/golem.R
@@ -197,9 +197,11 @@ golem <- function(x,
   if (is.null(response_names))
     response_names <- paste0("y", seq_len(m))
 
-  lipschitz_constant <- lipschitzConstant(family, x, fit_intercept)
-
   weights <- getWeights(penalty, x)
+
+  x <- sweep(x, 2, weights, "/")
+
+  lipschitz_constant <- lipschitzConstant(family, penalty, x, fit_intercept)
 
   control <- list(family = family,
                   penalty = penalty,
@@ -260,8 +262,10 @@ golem <- function(x,
     res <- golemFit(x, y, control)
   }
 
+  beta <- sweep(res$beta, 1, weights, "/")
+
   unstandardized_coefs <-
-    postProcess(penalty, res$intercept, res$beta, x, y, fit_intercept)
+    postProcess(penalty, res$intercept, beta, x, y, fit_intercept)
 
   beta <- unstandardized_coefs$betas
   intercept <- unstandardized_coefs$intercepts
@@ -316,7 +320,7 @@ golem <- function(x,
       p = p,
       m = m,
       diagnostics = diag,
-      passes = as.double(res$passes),
+      passes = as.integer(res$passes),
       call = ocall)
 }
 

--- a/R/lipschitz-constant.R
+++ b/R/lipschitz-constant.R
@@ -1,0 +1,23 @@
+#' @include families.R penalties.R
+
+setGeneric(
+  "lipschitzConstant",
+  function(family, penalty, x, fit_intercept)
+    standardGeneric("lipschitzConstant")
+)
+
+setMethod(
+  "lipschitzConstant",
+  c("Gaussian", "Penalty"),
+  function(family, penalty, x, fit_intercept) {
+    max(rowSums(x^2)) + fit_intercept
+  }
+)
+
+setMethod(
+  "lipschitzConstant",
+  c("Binomial", "Penalty"),
+  function(family, penalty, x, fit_intercept) {
+    0.25 * (max(rowSums(x^2)) + fit_intercept)
+  }
+)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -7,13 +7,13 @@
 using namespace Rcpp;
 
 // golemDense
-Rcpp::List golemDense(arma::mat x, arma::mat y, const Rcpp::List control);
+Rcpp::List golemDense(const arma::mat& x, const arma::mat& y, const Rcpp::List control);
 RcppExport SEXP _golem_golemDense(SEXP xSEXP, SEXP ySEXP, SEXP controlSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::mat >::type x(xSEXP);
-    Rcpp::traits::input_parameter< arma::mat >::type y(ySEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type x(xSEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type y(ySEXP);
     Rcpp::traits::input_parameter< const Rcpp::List >::type control(controlSEXP);
     rcpp_result_gen = Rcpp::wrap(golemDense(x, y, control));
     return rcpp_result_gen;

--- a/src/families.h
+++ b/src/families.h
@@ -7,17 +7,24 @@
 class Family {
 public:
   virtual
-  double
-  primal(const arma::mat& lin_pred, const arma::mat& y) = 0;
+  void
+  eval(const arma::mat& x,
+       const arma::mat& y,
+       const arma::vec& intercept,
+       const arma::mat& beta) = 0;
 
   virtual
   double
-  dual(const arma::mat& lin_pred, const arma::mat&y) = 0;
+  primal() = 0;
+
+  virtual
+  double
+  dual(const arma::mat&y) = 0;
 
   // this is not really the true gradient, and needs to multiplied by X'
   virtual
   arma::mat
-  gradient(const arma::mat& lin_pred, const arma::mat& y) = 0;
+  gradient(const arma::mat& y) = 0;
 
   virtual
   double
@@ -25,23 +32,44 @@ public:
 };
 
 class Gaussian : public Family {
-public:
-  Gaussian() {};
+private:
+  bool fit_intercept;
+  arma::vec residuals;
+  arma::mat lin_pred;
+  double loss = 0.0;
 
-  double
-  primal(const arma::mat& lin_pred, const arma::mat& y)
+public:
+  Gaussian(const bool fit_intercept) : fit_intercept(fit_intercept) {};
+
+  void
+  eval(const arma::mat& x,
+       const arma::mat& y,
+       const arma::vec& intercept,
+       const arma::mat& beta)
   {
-    return 0.5*std::pow(arma::norm(lin_pred - y), 2);
+    lin_pred = x * beta;
+
+    if (fit_intercept)
+      lin_pred += intercept(0);
+
+    residuals = lin_pred - y;
+    loss = 0.5*std::pow(arma::norm(residuals), 2);
   }
 
   double
-  dual(const arma::mat& lin_pred, const arma::mat& y)
+  primal()
   {
-    return -primal(lin_pred, y) - arma::dot(lin_pred - y, y);
+    return loss;
+  }
+
+  double
+  dual(const arma::mat& y)
+  {
+    return -loss - arma::dot(residuals, y);
   }
 
   arma::mat
-  gradient(const arma::mat& lin_pred, const arma::mat& y)
+  gradient(const arma::mat& y)
   {
     return lin_pred - y;
   }
@@ -54,27 +82,46 @@ public:
 };
 
 class Binomial : public Family {
-public:
-  Binomial() {};
+private:
+  const bool fit_intercept;
+  arma::mat lin_pred;
+  arma::mat exp_y_lin_pred;
 
-  double
-  primal(const arma::mat& lin_pred, const arma::mat& y)
+public:
+  Binomial(const bool fit_intercept) : fit_intercept(fit_intercept) {};
+
+  void
+  eval(const arma::mat& x,
+       const arma::mat& y,
+       const arma::vec& intercept,
+       const arma::mat& beta)
   {
-    return arma::accu(arma::log(1.0 + arma::exp(-y % lin_pred)));
+    lin_pred = x * beta;
+
+    if (fit_intercept)
+      lin_pred += intercept(0);
+
+    exp_y_lin_pred = arma::exp(y % lin_pred);
   }
 
   double
-  dual(const arma::mat& lin_pred, const arma::mat&y)
+  primal()
+  {
+    return arma::accu(arma::log(1.0 + 1.0/exp_y_lin_pred));
+  }
+
+  double
+  dual(const arma::mat&y)
   {
     using namespace arma;
-    const arma::vec r = 1.0/(1.0 + arma::exp(y % lin_pred));
+    const arma::vec r = 1.0/(1.0 + exp_y_lin_pred);
     return arma::as_scalar((r-1.0).t()*log(1.0-r) - r.t()*log(r));
   }
 
   arma::mat
-  gradient(const arma::mat& lin_pred, const arma::mat& y)
+  gradient(const arma::mat& y)
   {
-    return -y / (arma::exp(y % lin_pred) + 1.0);
+    return -y / (exp_y_lin_pred + 1.0);
   }
 
   double
@@ -92,11 +139,12 @@ public:
 // helper to choose family
 inline
 std::unique_ptr<Family>
-setupFamily(const std::string& family_choice)
+setupFamily(const std::string& family_choice,
+            const bool fit_intercept)
 {
   if (family_choice == "binomial")
-    return std::unique_ptr<Binomial>(new Binomial{});
+    return std::unique_ptr<Binomial>(new Binomial{fit_intercept});
   else
-    return std::unique_ptr<Gaussian>(new Gaussian{});
+    return std::unique_ptr<Gaussian>(new Gaussian{fit_intercept});
 }
 

--- a/src/golem.cpp
+++ b/src/golem.cpp
@@ -6,8 +6,8 @@
 
 // [[Rcpp::export]]
 Rcpp::List
-golemDense(arma::mat x,
-           arma::mat y,
+golemDense(const arma::mat& x,
+           const arma::mat& y,
            const Rcpp::List control)
 {
   using namespace arma;
@@ -40,11 +40,6 @@ golemDense(arma::mat x,
   rowvec intercept(m, fill::zeros);
   mat beta(p, m, fill::zeros);
 
-  // apply weights
-  auto weights = as<arma::vec>(control["weights"]);
-  for (uword j = 0; j < p; ++j)
-    x.col(j) /= weights(j);
-
   uvec passes(n_penalties);
   std::vector<std::vector<double>> primals;
   std::vector<std::vector<double>> duals;
@@ -59,7 +54,7 @@ golemDense(arma::mat x,
   for (uword i = 0; i < n_penalties; ++i) {
     Results res = solver.fit(x, y, family, penalty, fit_intercept);
 
-    betas.slice(i) = res.beta/weights;
+    betas.slice(i) = res.beta;
     intercepts.slice(i) = res.intercept;
     passes(i) = res.passes;
     penalty->step(i + 1); // move a step on the regularization path

--- a/src/golem.cpp
+++ b/src/golem.cpp
@@ -29,7 +29,7 @@ golemDense(arma::mat x,
   bool diagnostics = solver_args.slot("diagnostics");
 
   // // setup family and response
-  auto family = setupFamily(family_args.slot("name"));
+  auto family = setupFamily(family_args.slot("name"), fit_intercept);
   auto penalty = setupPenalty(penalty_args);
   auto n_penalties = penalty->pathLength();
 

--- a/src/golem.cpp
+++ b/src/golem.cpp
@@ -42,14 +42,8 @@ golemDense(arma::mat x,
 
   // apply weights
   auto weights = as<arma::vec>(control["weights"]);
-  // for (uword j = 0; j < p; ++j)
-  //   x.col(j) /= weights(j);
-  //
-  // weights.print();
-
-  mat Dinv = diagmat(1.0/weights);
-
-  x = x * Dinv;
+  for (uword j = 0; j < p; ++j)
+    x.col(j) /= weights(j);
 
   uvec passes(n_penalties);
   std::vector<std::vector<double>> primals;
@@ -65,7 +59,7 @@ golemDense(arma::mat x,
   for (uword i = 0; i < n_penalties; ++i) {
     Results res = solver.fit(x, y, family, penalty, fit_intercept);
 
-    betas.slice(i) = Dinv * res.beta;
+    betas.slice(i) = res.beta/weights;
     intercepts.slice(i) = res.intercept;
     passes(i) = res.passes;
     penalty->step(i + 1); // move a step on the regularization path

--- a/src/solvers.h
+++ b/src/solvers.h
@@ -58,7 +58,7 @@ private:
   arma::uword max_passes;
   double tol;
   const double eta = 2.0;
-  double L = 0;
+  double L = 1.0;
 
 public:
   FISTA(arma::rowvec&& intercept_init,
@@ -102,7 +102,6 @@ public:
     mat pseudo_g(g);
     rowvec g_intercept(m, fill::zeros);
 
-    // L = 1.0;
     double t = 1;
 
     uword i = 0;
@@ -112,6 +111,8 @@ public:
     double tol_infeas = 1e-6;
 
     tol_infeas *= penalty->lambdaInfeas();
+    tol_infeas =
+      tol_infeas < std::sqrt(datum::eps) ? std::sqrt(datum::eps) : tol_infeas;
 
     // diagnostics
     wall_clock timer;

--- a/tests/testthat/test-gaussian.R
+++ b/tests/testthat/test-gaussian.R
@@ -6,8 +6,8 @@ test_that("unregularized gaussian models work as expected", {
 
   lm_fit <- lm(y ~ x)
   golem_fit <- golem::golem(x, y, family = "gaussian",
-                            penalty = "slope",
-                            sigma = 0.01)
+                            sigma = 0,
+                            penalty = "slope")
 
   expect_equivalent(coef(lm_fit),
                     coef(golem_fit),

--- a/tests/testthat/test-group-slope.R
+++ b/tests/testthat/test-group-slope.R
@@ -4,7 +4,29 @@ test_that("results from group slope mirror those from grpSLOPE package", {
   grp <- rep(rep(1:20), each = 5)
   b   <- c(runif(20), rep(0, 80))
   # (i.e., groups 1, 2, 3, 4, are truly significant)
-  y   <- x %*% b + rnorm(10)
+  y   <- x %*% b + rnorm(100)
+  fdr <- 0.1 # target false discovery rate
+  sigma  <- 1
+
+  golem_fit <- golem(x, y,
+                     penalty = "group_slope",
+                     groups = grp,
+                     fdr = fdr,
+                     sigma = sigma)
+
+  gslope_fit <- grpSLOPE::grpSLOPE(x, y, group = grp, fdr = fdr, sigma = sigma)
+
+  expect_equivalent(coef(golem_fit), coef(gslope_fit, scaled = FALSE),
+                    tol = 1e-6)
+})
+
+test_that("uneven group input is handled correctly", {
+  set.seed(1)
+  x   <- matrix(rnorm(100^2), 100, 100)
+  grp <- sample(rep(rep(1:20), each = 5))
+  b   <- ifelse(grp %in% 1:5, runif(sum(grp %in% 1:5)), 0)
+  # (i.e., groups 1, 2, 3, 4, are truly significant)
+  y   <- x %*% b + rnorm(nrow(x))
   fdr <- 0.1 # target false discovery rate
   sigma  <- 1
 

--- a/tests/testthat/test-group-slope.R
+++ b/tests/testthat/test-group-slope.R
@@ -17,7 +17,7 @@ test_that("results from group slope mirror those from grpSLOPE package", {
   gslope_fit <- grpSLOPE::grpSLOPE(x, y, group = grp, fdr = fdr, sigma = sigma)
 
   expect_equivalent(coef(golem_fit), coef(gslope_fit, scaled = FALSE),
-                    tol = 1e-6)
+                    tol = 1e-5)
 })
 
 test_that("uneven group input is handled correctly", {


### PR DESCRIPTION
* Rework some of the classes for c++ to avoid redundant operations
* Move scaling out of c++ code and pass data by const ref
* Fix lipschitz constant computation for group slope. It was previously computed before feature scaling, causing large performance losses.