### PR TITLE
Allow setting of tolerance parameters to optimizer

### DIFF
--- a/R/golem.R
+++ b/R/golem.R
@@ -109,13 +109,14 @@ setClass("Golem",
 #' @param n_lambda length of regularization path (only relevant for lasso)
 #' @param lambda_min_ratio smallest value for `lambda` as a fraction of
 #'   \eqn{\lambda_\mathrm{max}}{\lambda_max} (only applies to lasso)
-#' @param tol tolerance for optimizer
 #' @param max_passes maximum number of passes for optimizer
 #' @param diagnostics should diagnostics be saved for the model fit (timings,
 #'   primal and dual objectives, and infeasibility)
 #' @param orthogonalize whether `x` should be orthogonalized. Note that
-#'   setting this to TRUE when `x` is sparse will through an error.
-#'   (only applies to Group SLOPE)
+#'   setting this to TRUE when `x` is sparse will through an error. (only
+#'   applies to Group SLOPE)
+#' @param tol_rel_gap relative tolerance threshold for duality gap check
+#' @param tol_infeas tolerance threshold for infeasibility
 #' @return An object of class `"Golem"`.
 #' @export
 #'
@@ -142,7 +143,8 @@ golem <- function(x,
                   fdr = 0.2,
                   n_lambda = 100,
                   lambda_min_ratio = ifelse(NROW(x) < NCOL(x), 0.01, 0.0001),
-                  tol = 1e-06,
+                  tol_rel_gap = 1e-6,
+                  tol_infeas = 1e-6,
                   max_passes = 1e4,
                   diagnostics = FALSE,
                   ...) {
@@ -232,7 +234,8 @@ golem <- function(x,
   is_slope <- inherits(penalty, "Slope") || inherits(penalty, "GroupSlope")
 
   # setup solver settings
-  solver <- Fista(tol = tol,
+  solver <- Fista(tol_rel_gap = tol_rel_gap,
+                  tol_infeas = tol_infeas,
                   max_passes = max_passes,
                   diagnostics = diagnostics)
 

--- a/R/solvers.R
+++ b/R/solvers.R
@@ -1,24 +1,26 @@
 setClass("Solver",
          slots = c(name = "character",
-                   tol = "numeric",
+                   tol_rel_gap = "numeric",
+                   tol_infeas = "numeric",
                    max_passes = "numeric",
-                   diagnostics = "logical"),
-         prototype = c(name = NA_character_,
-                       tol = NA_real_,
-                       max_passes = NA_real_,
-                       diagnostics = FALSE))
+                   diagnostics = "logical"))
 
 setClass("Fista",
          contains = "Solver")
 
-Fista <- function(tol = 1e-5, max_passes = 1e4, diagnostics = FALSE) {
+Fista <- function(tol_rel_gap = 1e-6,
+                  tol_infeas = 1e-6,
+                  max_passes = 1e4,
+                  diagnostics = FALSE) {
 
-  stopifnot(tol > 0,
+  stopifnot(tol_rel_gap >= 0,
+            tol_infeas >= 0,
             max_passes > 0)
 
   new("Fista",
       name = "fista",
-      tol = tol,
+      tol_rel_gap = tol_rel_gap,
+      tol_infeas = tol_infeas,
       max_passes = max_passes,
       diagnostics = diagnostics)
 }

--- a/man/golem.Rd
+++ b/man/golem.Rd
@@ -9,7 +9,8 @@ golem(x, y, groups = NULL, family = c("gaussian", "binomial"),
   intercept = TRUE, standardize_features = TRUE,
   orthogonalize = TRUE, sigma = NULL, lambda = NULL, fdr = 0.2,
   n_lambda = 100, lambda_min_ratio = ifelse(NROW(x) < NCOL(x), 0.01,
-  1e-04), tol = 1e-06, max_passes = 10000, diagnostics = FALSE, ...)
+  1e-04), tol_rel_gap = 1e-06, tol_infeas = 1e-06,
+  max_passes = 10000, diagnostics = FALSE, ...)
 }
 \arguments{
 \item{x}{feature matrix}
@@ -31,8 +32,8 @@ details.}
 \item{standardize_features}{whether to standardize features (predictors)}
 
 \item{orthogonalize}{whether \code{x} should be orthogonalized. Note that
-setting this to TRUE when \code{x} is sparse will through an error.
-(only applies to Group SLOPE)}
+setting this to TRUE when \code{x} is sparse will through an error. (only
+applies to Group SLOPE)}
 
 \item{sigma}{noise estimate (only applies to SLOPE and Group SLOPE)}
 
@@ -47,7 +48,9 @@ Group SLOPE)}
 \item{lambda_min_ratio}{smallest value for \code{lambda} as a fraction of
 \eqn{\lambda_\mathrm{max}}{\lambda_max} (only applies to lasso)}
 
-\item{tol}{tolerance for optimizer}
+\item{tol_rel_gap}{relative tolerance threshold for duality gap check}
+
+\item{tol_infeas}{tolerance threshold for infeasibility}
 
 \item{max_passes}{maximum number of passes for optimizer}
 

--- a/src/solvers.h
+++ b/src/solvers.h
@@ -51,8 +51,9 @@ private:
   arma::vec x_scaled_center;
   const bool is_sparse;
   arma::uword max_passes;
-  double tol;
   const double eta = 2.0;
+  double tol_rel_gap = 1e-6;
+  double tol_infeas = 1e-6;
 
 public:
   FISTA(arma::rowvec&& intercept_init,
@@ -73,8 +74,9 @@ public:
     beta        = std::move(beta_init);
 
     max_passes  = args.slot("max_passes");
-    tol         = args.slot("tol");
     diagnostics = args.slot("diagnostics");
+    tol_rel_gap = args.slot("tol_rel_gap");
+    tol_infeas  = args.slot("tol_infeas");
   }
 
   template <typename T>
@@ -107,9 +109,6 @@ public:
 
     uword i = 0;
     bool accepted = false;
-
-    double tol_rel_gap = 1e-6;
-    double tol_infeas = 1e-6;
 
     tol_infeas *= penalty->lambdaInfeas();
     tol_infeas =


### PR DESCRIPTION
Previously, the settings were hard-coded and the available argument `tol` was not used. Now we introduce the real arguments and allow the user to set them.