### PR TITLE
Enable warm starts

### DIFF
--- a/man/golem.Rd
+++ b/man/golem.Rd
@@ -64,7 +64,7 @@ each family plus a penalty term.
 
 
 \describe{
-\item{\code{fit(x, y, groups = NULL, ...)}}{
+\item{\code{fit(x, y, groups = NULL, warm_start = TRUE, ...)}}{
 This method fits models specified by \code{\link[=golem]{golem()}}.
 \describe{
 \item{\code{x}}{
@@ -80,6 +80,13 @@ binomial models, it can be a factor.
 \item{\code{groups}}{
 a vector of integers giving the group membership of each
 feature (only applies to Group SLOPE)
+}
+\item{\code{warm_start}}{
+whether to use the coefficient estimates from the previous
+fit when refitting the model using new data. Provided that
+the same penalty (with approximately the same parameters)
+id used, setting this to true might lead to
+substantial performance boosts.
 }
 \item{\code{\dots}}{
 arguments that will be used to modify the original model

--- a/src/golem.cpp
+++ b/src/golem.cpp
@@ -45,9 +45,9 @@ golemCpp(const T& x,
   cube betas(p, m, n_penalties);
   cube intercepts(1, m, n_penalties);
 
-  // setup a few return values
-  rowvec intercept(m, fill::zeros);
-  mat beta(p, m, fill::zeros);
+  // initialize estimates
+  auto intercept_init = as<rowvec>(control["intercept_init"]);
+  auto beta_init      = as<mat>(control["beta_init"]);
 
   uvec passes(n_penalties);
   std::vector<std::vector<double>> primals;
@@ -55,8 +55,8 @@ golemCpp(const T& x,
   std::vector<std::vector<double>> timings;
   std::vector<std::vector<double>> infeasibilities;
 
-  FISTA solver(std::move(intercept),
-               std::move(beta),
+  FISTA solver(intercept_init,
+               beta_init,
                lipschitz_constant,
                standardize_features,
                x_scaled_center,

--- a/tests/testthat/test-gaussian.R
+++ b/tests/testthat/test-gaussian.R
@@ -7,7 +7,7 @@ test_that("unregularized gaussian models work as expected", {
   g <- golem(family = "gaussian",
              sigma = 1e-4,
              penalty = "slope")
-  g$fit(x, y)
+  g$fit(x, y, warm_start = FALSE)
 
   expect_equivalent(coef(lm_fit),
                     g$coef(),

--- a/tests/testthat/test-lasso.R
+++ b/tests/testthat/test-lasso.R
@@ -11,3 +11,20 @@ test_that("lasso induces sparse models", {
 
   expect_equivalent(glm_fit$lambda, fit$penalty$lambda, tol = 1e-4)
 })
+
+test_that("lasso and slope fits are equivalent if all lambda are equal", {
+  set.seed(1)
+  xy <- golem:::randomProblem(100, 10)
+  x <- xy$x
+  y <- xy$y
+
+  model <- golem(penalty = "lasso", lambda = 0.2)
+  model$fit(x, y)
+  lasso_coef <- model$coef()
+
+  model$fit(x, y, penalty = "slope",
+            lambda = rep(0.2, NCOL(x))*NROW(x), sigma = 1)
+  slope_coef <- model$coef()
+
+  expect_equal(lasso_coef, slope_coef)
+})

--- a/tests/testthat/test-lasso.R
+++ b/tests/testthat/test-lasso.R
@@ -1,4 +1,5 @@
 test_that("lasso induces sparse models", {
+  set.seed(1)
   x <- with(mtcars, cbind(mpg, disp))
   y <- mtcars$hp
 
@@ -22,7 +23,7 @@ test_that("lasso and slope fits are equivalent if all lambda are equal", {
   model$fit(x, y)
   lasso_coef <- model$coef()
 
-  model$fit(x, y, penalty = "slope",
+  model$fit(x, y, penalty = "slope", warm_start = FALSE,
             lambda = rep(0.2, NCOL(x))*NROW(x), sigma = 1)
   slope_coef <- model$coef()
 

--- a/tests/testthat/test-warm-starts.R
+++ b/tests/testthat/test-warm-starts.R
@@ -1,0 +1,16 @@
+test_that("warm starts reduce number of passes if used properly", {
+  set.seed(3)
+
+  xy <- golem:::randomProblem(1000, 10)
+  x <- xy$x
+  y <- xy$y
+
+  model <- golem(penalty = "slope")
+  model$fit(x[1:500, ], y[1:500])
+  passes_1 <- model$passes
+
+  model$fit(x[501:1000, ], y[501:1000], warm_start = TRUE)
+  passes_2 <- model$passes
+
+  expect_gt(passes_1, passes_2)
+})


### PR DESCRIPTION
Introduce warm starts by storing coefficients from previous fits and use those as starting points for new fits. If, for some reason, the necessary dimensions of the new data does not match the previous data, we simply ignore this (without warning at the moment, but we should perhaps reconsider).

In addition, there is a small fix for a mistake in the algorithm where the wrong beta was used, which should save us at least one iteration for each run.