### PR TITLE
Pursue a more natual implementation of indexing penalties along the path

### DIFF
--- a/src/golem.cpp
+++ b/src/golem.cpp
@@ -63,13 +63,12 @@ golemCpp(const T& x,
                is_sparse,
                solver_args);
 
-  for (uword i = 0; i < n_penalties; ++i) {
-    Results res = solver.fit(x, y, family, penalty, fit_intercept);
+  for (uword path_iter = 0; path_iter < n_penalties; ++path_iter) {
+    Results res = solver.fit(x, y, family, penalty, fit_intercept, path_iter);
 
-    betas.slice(i) = res.beta;
-    intercepts.slice(i) = res.intercept;
-    passes(i) = res.passes;
-    penalty->step(i + 1); // move a step on the regularization path
+    betas.slice(path_iter) = res.beta;
+    intercepts.slice(path_iter) = res.intercept;
+    passes(path_iter) = res.passes;
 
     if (diagnostics) {
       primals.push_back(res.primals);

--- a/src/r-exports.cpp
+++ b/src/r-exports.cpp
@@ -10,7 +10,7 @@ prox_slope_cpp(const arma::vec& y, const Rcpp::List& args)
 
   SLOPE penalty{sigma, lambda};
 
-  return penalty.eval(y, 1.0);
+  return penalty.eval(y, 1.0, 0);
 }
 
 

--- a/src/solvers.h
+++ b/src/solvers.h
@@ -85,7 +85,8 @@ public:
       const arma::mat& y,
       const std::unique_ptr<Family>& family,
       const std::unique_ptr<Penalty>& penalty,
-      const bool fit_intercept)
+      const bool fit_intercept,
+      const arma::uword path_iter)
   {
     using namespace arma;
 
@@ -110,7 +111,7 @@ public:
     uword i = 0;
     bool accepted = false;
 
-    tol_infeas *= penalty->lambdaInfeas();
+    tol_infeas *= penalty->lambdaInfeas(path_iter);
     tol_infeas =
       tol_infeas < std::sqrt(datum::eps) ? std::sqrt(datum::eps) : tol_infeas;
 
@@ -143,9 +144,9 @@ public:
       if (fit_intercept)
         g_intercept = mean(pseudo_g);
 
-      double primal = f + penalty->primal(beta);
+      double primal = f + penalty->primal(beta, path_iter);
       double dual = family->dual(y);
-      double infeasibility = penalty->infeasibility(g);
+      double infeasibility = penalty->infeasibility(g, path_iter);
 
       accepted = (std::abs(primal - dual)/std::max(1.0, primal) < tol_rel_gap)
                   && (infeasibility <= tol_infeas);
@@ -171,7 +172,7 @@ public:
       // // Lipschitz search
       while (true) {
         // Update beta and intercept
-        beta_tilde = penalty->eval(beta - (1.0/L)*g, 1.0/L);
+        beta_tilde = penalty->eval(beta - (1.0/L)*g, 1.0/L, path_iter);
 
         mat d = beta_tilde - beta;
         if (fit_intercept)


### PR DESCRIPTION
This change means that we explicitly select the current lambda along the path. With this change, it should be very easy to implement pathwise fitting also for the SLOPE types of penalties.