### PR TITLE
User interrupts and better selection of regularization path

### DIFF
--- a/R/golem.R
+++ b/R/golem.R
@@ -95,8 +95,6 @@
 #'   applies to Group SLOPE)
 #' @param sigma noise estimate (only applies to SLOPE and Group SLOPE)
 #' @param n_sigma length of regularization path (only relevant for group slope)
-#' @param sigma_min_ratio smallest value for `sigma` as a fraction of
-#'  `sigma_max`
 #' @param lambda either a character vector indicating the method used
 #'   to construct the lambda path or the a vector or matrix
 #' @param n_lambda length of regularization path (only relevant for lasso)
@@ -143,7 +141,6 @@ golem <- function(x,
                   orthogonalize = TRUE,
                   sigma = c("sequence", "estimate"),
                   n_sigma = 100,
-                  sigma_min_ratio = NULL,
                   lambda = NULL,
                   n_lambda = 100,
                   lambda_min_ratio = NULL,
@@ -173,8 +170,6 @@ golem <- function(x,
     fdr < 1,
     is.character(sigma) ||
       (all(sigma >= 0 & is.finite(sigma))),
-    is.null(sigma_min_ratio) ||
-      (sigma_min_ratio > 0 && sigma_min_ratio < 1),
     length(n_sigma) == 1,
     n_sigma >= 1,
     is.null(lambda) ||
@@ -281,7 +276,7 @@ golem <- function(x,
                   y_scale = y_scale,
                   lambda = lambda,
                   sigma = sigma,
-                  sigma_min_ratio = sigma_min_ratio,
+                  lambda_min_ratio = lambda_min_ratio,
                   n_sigma = n_sigma,
                   fdr = fdr,
                   family = family),
@@ -292,7 +287,7 @@ golem <- function(x,
                              groups = groups,
                              lambda = lambda,
                              sigma = sigma,
-                             sigma_min_ratio = sigma_min_ratio,
+                             lambda_min_ratio = lambda_min_ratio,
                              n_sigma = n_sigma,
                              fdr = fdr,
                              family = family),

--- a/R/lambdaMax.R
+++ b/R/lambdaMax.R
@@ -14,7 +14,7 @@ lambdaMax <- function(object, x, y, y_scale) {
 
 #' @rdname lambdaMax
 lambdaMax.Gaussian <- function(object, x, y, y_scale) {
-  y_scale * max(abs(crossprod(x, y))) / NROW(x)
+  y_scale * abs(crossprod(x, y))
 }
 
 #' @rdname lambdaMax
@@ -28,5 +28,5 @@ lambdaMax.Binomial <- function(object, x, y, y_scale) {
 
   y <- (y - y_bar) / y_sd
 
-  y_sd * max(abs(crossprod(x, y))) / NROW(x)
+  y_sd * abs(crossprod(x, y))
 }

--- a/src/golem.cpp
+++ b/src/golem.cpp
@@ -81,6 +81,8 @@ golemCpp(const T& x,
       infeasibilities.push_back(res.infeasibilities);
       timings.push_back(res.time);
     }
+
+    Rcpp::checkUserInterrupt();
   }
 
   return Rcpp::List::create(

--- a/src/solvers.h
+++ b/src/solvers.h
@@ -217,6 +217,9 @@ public:
 
       if (fit_intercept)
         lin_pred += intercept(0);
+
+      if (passes % 100 == 0)
+        Rcpp::checkUserInterrupt();
     }
 
     Results res{intercept,


### PR DESCRIPTION
* Now select regularization path so that coefficients always start to enter the model on the second step.
* Add user interrupts via Rccpp::checkForUserInterrupt() in and between fits